### PR TITLE
actor-errors

### DIFF
--- a/contracts/v0.8/utils/Actor.sol
+++ b/contracts/v0.8/utils/Actor.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.8.17;
 
 import "./Misc.sol";
 import "../types/CommonTypes.sol";
+import {Errors} from "./Errors.sol";
 
 /// @title Call actors utilities library, meant to interact with Filecoin builtin actors
 /// @author Zondax AG
@@ -219,7 +220,7 @@ library Actor {
         }
 
         if (exit != 0) {
-            revert ActorError(exit);
+            Errors.revertWith(exit);
         }
 
         return return_value;

--- a/contracts/v0.8/utils/Errors.sol
+++ b/contracts/v0.8/utils/Errors.sol
@@ -47,16 +47,16 @@ library Errors {
     error DealExpired();
 
     function revertWith(int256 exitCode) internal pure {
-        if (exitCode == USR_ILLEGAL_ARGUMENT) revert IllegalArgument();
-        if (exitCode == USR_NOT_FOUND) revert NotFound();
-        if (exitCode == USR_FORBIDDEN) revert Forbidden();
-        if (exitCode == USR_INSUFFICIENT_FUNDS) revert UserInsufficientFunds();
-        if (exitCode == USR_ILLEGAL_STATE) revert IllegalState();
-        if (exitCode == USR_SERIALIZATION) revert Serialization();
-        if (exitCode == USR_UNHANDLED_MESSAGE) revert UnhandledMessage();
-        if (exitCode == USR_UNSPECIFIED) revert Unspecified();
-        if (exitCode == USR_ASSERTION_FAILED) revert UserAssertionFailed();
-        if (exitCode == FIRST_ACTOR_SPECIFIC_EXIT_CODE) revert DealExpired();
+        if (exitCode == USR_ILLEGAL_ARGUMENT) revert USR_ILLEGAL_ARGUMENT();
+        if (exitCode == USR_NOT_FOUND) revert USR_NOT_FOUND();
+        if (exitCode == USR_FORBIDDEN) revert USR_FORBIDDEN();
+        if (exitCode == USR_INSUFFICIENT_FUNDS) revert USR_INSUFFICIENT_FUNDS();
+        if (exitCode == USR_ILLEGAL_STATE) revert USR_ILLEGAL_STATE();
+        if (exitCode == USR_SERIALIZATION) revert USR_SERIALIZATION();
+        if (exitCode == USR_UNHANDLED_MESSAGE) revert USR_UNHANDLED_MESSAGE();
+        if (exitCode == USR_UNSPECIFIED) revert USR_UNSPECIFIED();
+        if (exitCode == USR_ASSERTION_FAILED) revert USR_ASSERTION_FAILED();
+        if (exitCode == FIRST_ACTOR_SPECIFIC_EXIT_CODE) revert DEAL_EXPIRED();
 
         revert("Unknown error code");
     }

--- a/contracts/v0.8/utils/Errors.sol
+++ b/contracts/v0.8/utils/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.18;
 
 /// @notice This is the library for various Errors returned from FVM.
 

--- a/contracts/v0.8/utils/Errors.sol
+++ b/contracts/v0.8/utils/Errors.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.17;
+
+/// @notice This is the library for various Errors returned from FVM.
+
+library Errors {
+    // Error codes
+    int256 constant USR_ILLEGAL_ARGUMENT = 16;
+    int256 constant USR_NOT_FOUND = 17;
+    int256 constant USR_FORBIDDEN = 18;
+    int256 constant USR_INSUFFICIENT_FUNDS = 19;
+    int256 constant USR_ILLEGAL_STATE = 20;
+    int256 constant USR_SERIALIZATION = 21;
+    int256 constant USR_UNHANDLED_MESSAGE = 22;
+    int256 constant USR_UNSPECIFIED = 23;
+    int256 constant USR_ASSERTION_FAILED = 24;
+    int256 constant FIRST_ACTOR_SPECIFIC_EXIT_CODE = 32;
+
+    // Indicates a method parameter is invalid.
+    error IllegalArgument();
+
+    // Indicates a requested resource does not exist.
+    error NotFound();
+
+    // Indicates an action is not permitted.
+    error Forbidden();
+
+    // Indicates a balance of funds is insufficient.
+    error UserInsufficientFunds();
+
+    // Indicates an actor's internal state is invalid.
+    error IllegalState();
+
+    // Indicates de/serialization failure within actor code.
+    error Serialization();
+
+    // Indicates the actor cannot handle this message.
+    error UnhandledMessage();
+
+    // Indicates the actor failed with an unspecified error.
+    error Unspecified();
+
+    // Indicates the actor failed a user-level assertion
+    error UserAssertionFailed();
+
+    // Indicates expired deal
+    error DealExpired();
+
+    function revertWith(int256 exitCode) internal pure {
+        if (exitCode == USR_ILLEGAL_ARGUMENT) revert IllegalArgument();
+        if (exitCode == USR_NOT_FOUND) revert NotFound();
+        if (exitCode == USR_FORBIDDEN) revert Forbidden();
+        if (exitCode == USR_INSUFFICIENT_FUNDS) revert UserInsufficientFunds();
+        if (exitCode == USR_ILLEGAL_STATE) revert IllegalState();
+        if (exitCode == USR_SERIALIZATION) revert Serialization();
+        if (exitCode == USR_UNHANDLED_MESSAGE) revert UnhandledMessage();
+        if (exitCode == USR_UNSPECIFIED) revert Unspecified();
+        if (exitCode == USR_ASSERTION_FAILED) revert UserAssertionFailed();
+        if (exitCode == FIRST_ACTOR_SPECIFIC_EXIT_CODE) revert DealExpired();
+
+        revert("Unknown error code");
+    }
+}


### PR DESCRIPTION
- Fixes  #3 


resolving unconditional revert discussed in issue [https://github.com/Zondax/filecoin-solidity/issues/363](https://github.com/Zondax/filecoin-solidity/issues/363) . Defined error codes in new files and reverted them in [actor.sol](https://github.com/lordshashank/filecoin-solidity-library/blob/actor-errors/contracts/v0.8/utils/Actor.sol#L223C1-L223C13).
Have defined actor errors only defined [here](https://docs.rs/fil_actors_runtime/latest/src/fil_actors_runtime/actor_error.rs.html#24).
Tested it for deal expiration and non-existent deals. Any additional features and improvement in code is invited.