### PR TITLE
Implementation of toEthAddress function 

### DIFF
--- a/contracts/v0.8/tests/filladdress.test.sol
+++ b/contracts/v0.8/tests/filladdress.test.sol
@@ -8,9 +8,9 @@ import {CommonTypes} from "contracts/v0.8/types/CommonTypes.sol";
 import "forge-std/console.sol";
 
 contract FilAddressesTest is Test {
-    error InvalidAddress();
-
     address testAddress = makeAddr("testaddress");
+    
+    error InvalidAddress();
 
     // UNIT TESTS
     function test_fromEthAddress() external {

--- a/contracts/v0.8/tests/filladdress.test.sol
+++ b/contracts/v0.8/tests/filladdress.test.sol
@@ -77,8 +77,13 @@ contract FilAddressesTest is Test {
         result = FilAddresses.fromBytes(invalidInput);
     }
 
-    function test_validate() external pure {
-        CommonTypes.FilAddress memory inputAddress = CommonTypes.FilAddress(hex"00");
+    function test_validate() external view {
+        CommonTypes.FilAddress memory inputAddress = CommonTypes.FilAddress(hex"0001");
+        assert(FilAddresses.validate(inputAddress));
+        
+        // failing because of the payload length
+        inputAddress = FilAddresses.fromActorID(type(uint64).max);
+        console.log(inputAddress.data.length);
         assert(FilAddresses.validate(inputAddress));
 
         inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"01", new bytes(20)));

--- a/contracts/v0.8/tests/filladdress.test.sol
+++ b/contracts/v0.8/tests/filladdress.test.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {FilAddresses} from "contracts/v0.8/utils/FilAddresses.sol";
+import {FilAddressIdConverter} from "contracts/v0.8/utils/FilAddressIdConverter.sol";
+import {CommonTypes} from "contracts/v0.8/types/CommonTypes.sol";
+import "forge-std/console.sol";
+
+contract FilAddressesTest is Test {
+    error InvalidAddress();
+
+    address testAddress = makeAddr("testaddress");
+
+    // UNIT TESTS
+    function test_fromEthAddress() external {
+        bytes memory filAddress = FilAddresses.fromEthAddress(testAddress).data;
+        assertEq(filAddress, abi.encodePacked(hex"040a", testAddress));
+    }
+
+    function test_toEthAddress() external {
+        CommonTypes.FilAddress memory filAddress = CommonTypes.FilAddress(abi.encodePacked(hex"040a", testAddress));
+        address ethAddress = FilAddresses.toEthAddress(filAddress);
+        assertEq(testAddress, ethAddress);
+    }
+
+    function test_toEthAddressWhenInputIsInvalid() external {
+        CommonTypes.FilAddress memory invalidFilAddress = CommonTypes.FilAddress(abi.encodePacked(hex"000a", testAddress));
+
+        vm.expectRevert(InvalidAddress.selector);
+        address ethAddress = FilAddresses.toEthAddress(invalidFilAddress);
+
+        invalidFilAddress = CommonTypes.FilAddress(abi.encodePacked(hex"0400", testAddress));
+
+        vm.expectRevert(InvalidAddress.selector);
+        ethAddress = FilAddresses.toEthAddress(invalidFilAddress);
+
+        invalidFilAddress = CommonTypes.FilAddress(abi.encodePacked(hex"040000", testAddress));
+
+        vm.expectRevert(InvalidAddress.selector);
+        ethAddress = FilAddresses.toEthAddress(invalidFilAddress);
+    }
+
+    function test_fromActorID() external {
+        CommonTypes.FilAddress memory result = FilAddresses.fromActorID(1000);
+        assertEq(keccak256(result.data), keccak256(hex"00e807"));
+    }
+
+    function test_fromBytes() external {
+        CommonTypes.FilAddress memory result = FilAddresses.fromBytes(hex"000a");
+        assertEq(keccak256(result.data), keccak256(hex"000a"));
+    }
+
+    function test_fromBytesWhenInputIsInvalid() external {
+        bytes memory invalidInput = abi.encodePacked(hex"00", new bytes(10));
+        vm.expectRevert(InvalidAddress.selector);
+        CommonTypes.FilAddress memory result = FilAddresses.fromBytes(invalidInput);
+
+        invalidInput = abi.encodePacked(hex"01", new bytes(21));
+        vm.expectRevert(InvalidAddress.selector);
+        result = FilAddresses.fromBytes(invalidInput);
+
+        invalidInput = abi.encodePacked(hex"02", new bytes(21));
+        vm.expectRevert(InvalidAddress.selector);
+        result = FilAddresses.fromBytes(invalidInput);
+
+        invalidInput = abi.encodePacked(hex"03", new bytes(49));
+        vm.expectRevert(InvalidAddress.selector);
+        result = FilAddresses.fromBytes(invalidInput);
+
+        invalidInput = abi.encodePacked(hex"04", new bytes(64));
+        vm.expectRevert(InvalidAddress.selector);
+        result = FilAddresses.fromBytes(invalidInput);
+    }
+
+    function test_validate() external pure {
+        CommonTypes.FilAddress memory inputAddress = CommonTypes.FilAddress(hex"00");
+        assert(FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"01", new bytes(20)));
+        assert(FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"02", new bytes(20)));
+        assert(FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"03", new bytes(48)));
+        assert(FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"04", new bytes(63)));
+        assert(FilAddresses.validate(inputAddress));
+    }
+
+    // FUZZING TESTS
+    function test_validateWhenInputIsInvalid() external pure {
+        CommonTypes.FilAddress memory inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"00", new bytes(10)));
+        assert(!FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"01", new bytes(19)));
+        assert(!FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"02", new bytes(19)));
+        assert(!FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"03", new bytes(47)));
+        assert(!FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"04", new bytes(64)));
+        assert(!FilAddresses.validate(inputAddress));
+    }
+
+    function testFuzz_toEthAddressInvalidFirstByte(address addr, bytes1 firstByte) public {
+        vm.assume(firstByte != hex"04");
+        CommonTypes.FilAddress memory filAddress = CommonTypes.FilAddress(abi.encodePacked(firstByte, hex"0a", addr));
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.toEthAddress(filAddress);
+    }
+
+    function testFuzz_toEthAddressInvalidSecondByte(address addr, bytes1 secondByte) public {
+        vm.assume(secondByte != hex"0a");
+        CommonTypes.FilAddress memory filAddress = CommonTypes.FilAddress(abi.encodePacked(hex"04", secondByte, addr));
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.toEthAddress(filAddress);
+    }
+
+    function testFuzz_toEthAddressInvalidBytesLength(address addr, bytes1 endByte) public {
+        CommonTypes.FilAddress memory filAddress = CommonTypes.FilAddress(abi.encodePacked("040b", addr, endByte));
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.toEthAddress(filAddress);
+    }
+
+    function testFuzz_toEthAddress(address addr) public {
+        bytes memory addrBytes = abi.encodePacked(addr);
+        bytes memory filAddressBytes = abi.encodePacked(hex"040a", addrBytes);
+        CommonTypes.FilAddress memory filAddress = CommonTypes.FilAddress(filAddressBytes);
+
+        address ethAddress = FilAddresses.toEthAddress(filAddress);
+
+        assertEq(addr, ethAddress);
+    }
+
+    function testFuzz_fromEthAddress(address addr) public {
+        bytes memory addrBytes = abi.encodePacked(addr);
+        bytes memory filAddressBytes = abi.encodePacked(hex"040a", addrBytes);
+
+        CommonTypes.FilAddress memory filAddress = FilAddresses.fromEthAddress(addr);
+
+        assertEq(filAddressBytes, filAddress.data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x00(bytes memory data) public {
+        vm.assume(data.length > 0 && data.length <= 10);
+        data[0] = 0x00;
+
+        CommonTypes.FilAddress memory filAddress = FilAddresses.fromBytes(data);
+        assertEq(data, filAddress.data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x00InvalidLength(bytes memory data) public {
+        vm.assume(data.length > 10);
+        data[0] = 0x00;
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.fromBytes(data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x01(bytes memory data) public {
+        vm.assume(data.length == 21);
+        data[0] = 0x01;
+
+        CommonTypes.FilAddress memory filAddress = FilAddresses.fromBytes(data);
+        assertEq(data, filAddress.data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x01InvalidLength(bytes memory data) public {
+        vm.assume(data.length > 0 && data.length != 21);
+        data[0] = 0x01;
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.fromBytes(data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x02(bytes memory data) public {
+        vm.assume(data.length == 21);
+        data[0] = 0x02;
+
+        CommonTypes.FilAddress memory filAddress = FilAddresses.fromBytes(data);
+        assertEq(data, filAddress.data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x02InvalidLength(bytes memory data) public {
+        vm.assume(data.length > 0 && data.length != 21);
+        data[0] = 0x02;
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.fromBytes(data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x03(bytes memory data) public {
+        vm.assume(data.length == 49);
+        data[0] = 0x03;
+
+        CommonTypes.FilAddress memory filAddress = FilAddresses.fromBytes(data);
+        assertEq(data, filAddress.data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x03InvalidLength(bytes memory data) public {
+        vm.assume(data.length > 0 && data.length != 49);
+        data[0] = 0x03;
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.fromBytes(data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x04(bytes memory data) public {
+        vm.assume(data.length > 0 && data.length <= 64);
+        data[0] = 0x04;
+
+        CommonTypes.FilAddress memory filAddress = FilAddresses.fromBytes(data);
+        assertEq(data, filAddress.data);
+    }
+
+    function testFuzz_fromBytesFirstByte0x04InvalidLength(bytes memory data) public {
+        vm.assume(data.length > 64);
+        data[0] = 0x04;
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.fromBytes(data);
+    }
+
+    function testFuzz_fromBytesFirstByteOtherInvalid(bytes memory data) public {
+        vm.assume(data.length > 0 && data.length <= 256 && data[0] > 0x04);
+
+        vm.expectRevert(InvalidAddress.selector);
+        FilAddresses.fromBytes(data);
+    }
+
+    function testFromActorId(uint64 actorId) public {
+        vm.assume(actorId > 0 && actorId < 50);
+        // conversion to uint16 needed to get actorId in two bytes
+        bytes memory actorIdBytes = abi.encodePacked(uint16(actorId));
+        CommonTypes.FilAddress memory filAddress = FilAddresses.fromActorID(actorId);
+        assertEq(filAddress.data, actorIdBytes);
+    }
+}

--- a/contracts/v0.8/tests/filladdress.test.sol
+++ b/contracts/v0.8/tests/filladdress.test.sol
@@ -35,7 +35,7 @@ contract FilAddressesTest is Test {
         vm.expectRevert(InvalidAddress.selector);
         ethAddress = FilAddresses.toEthAddress(invalidFilAddress);
 
-        invalidFilAddress = CommonTypes.FilAddress(abi.encodePacked(hex"040000", testAddress));
+        invalidFilAddress = CommonTypes.FilAddress(abi.encodePacked(hex"040a00", testAddress));
 
         vm.expectRevert(InvalidAddress.selector);
         ethAddress = FilAddresses.toEthAddress(invalidFilAddress);
@@ -71,6 +71,10 @@ contract FilAddressesTest is Test {
         invalidInput = abi.encodePacked(hex"04", new bytes(64));
         vm.expectRevert(InvalidAddress.selector);
         result = FilAddresses.fromBytes(invalidInput);
+
+        invalidInput = abi.encodePacked(hex"05", new bytes(64));
+        vm.expectRevert(InvalidAddress.selector);
+        result = FilAddresses.fromBytes(invalidInput);
     }
 
     function test_validate() external pure {
@@ -90,7 +94,6 @@ contract FilAddressesTest is Test {
         assert(FilAddresses.validate(inputAddress));
     }
 
-    // FUZZING TESTS
     function test_validateWhenInputIsInvalid() external pure {
         CommonTypes.FilAddress memory inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"00", new bytes(10)));
         assert(!FilAddresses.validate(inputAddress));
@@ -106,8 +109,12 @@ contract FilAddressesTest is Test {
 
         inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"04", new bytes(64)));
         assert(!FilAddresses.validate(inputAddress));
+
+        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"05", new bytes(64)));
+        assert(!FilAddresses.validate(inputAddress));
     }
 
+    // FUZZING TESTS
     function testFuzz_toEthAddressInvalidFirstByte(address addr, bytes1 firstByte) public {
         vm.assume(firstByte != hex"04");
         CommonTypes.FilAddress memory filAddress = CommonTypes.FilAddress(abi.encodePacked(firstByte, hex"0a", addr));

--- a/contracts/v0.8/tests/filladdress.test.sol
+++ b/contracts/v0.8/tests/filladdress.test.sol
@@ -118,18 +118,6 @@ contract FilAddressesTest is Test {
         FilAddresses.fromBytes(invalidInput);
     }
 
-    function test_fromBytesFirstByte0x04InvalidInputSecondByte() external {
-        bytes memory invalidInput = abi.encodePacked(hex"0400", new bytes(20));
-        vm.expectRevert(InvalidAddress.selector);
-        FilAddresses.fromBytes(invalidInput);
-    }
-
-    function test_fromBytesInvalidFirstByte() external {
-        bytes memory invalidInput = abi.encodePacked(hex"05", new bytes(10));
-        vm.expectRevert(InvalidAddress.selector);
-        FilAddresses.fromBytes(invalidInput);
-    }
-
     function test_validate() external pure {
         CommonTypes.FilAddress memory inputAddress = CommonTypes.FilAddress(hex"0001");
         assert(FilAddresses.validate(inputAddress));
@@ -167,12 +155,6 @@ contract FilAddressesTest is Test {
         assert(!FilAddresses.validate(inputAddress));
 
         inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"040a", new bytes(21)));
-        assert(!FilAddresses.validate(inputAddress));
-
-        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"0400", new bytes(20)));
-        assert(!FilAddresses.validate(inputAddress));
-
-        inputAddress = CommonTypes.FilAddress(abi.encodePacked(hex"05", new bytes(64)));
         assert(!FilAddresses.validate(inputAddress));
     }
 
@@ -292,29 +274,10 @@ contract FilAddressesTest is Test {
         assertEq(data, filAddress.data);
     }
 
-    function testFuzz_fromBytesFirstByte0x04InvalidSecondByte(bytes memory data, bytes1 secondByte) public {
-        vm.assume(data.length == 22 && secondByte != hex"0a");
-        data[0] = 0x04;
-        data[1] = secondByte;
-
-        vm.expectRevert(InvalidAddress.selector);
-        FilAddresses.fromBytes(data);
-    }
-
     function testFuzz_fromBytesFirstByte0x04InvalidLength(bytes memory data) public {
         vm.assume(data.length > 1 && data.length != 22);
         data[0] = 0x04;
         data[1] = 0x0a;
-
-        vm.expectRevert(InvalidAddress.selector);
-        FilAddresses.fromBytes(data);
-    }
-
-    function testFuzz_fromBytesInvalidFirstByte(bytes memory data) public {
-        vm.assume(
-            ((data.length > 1 && data.length <= 11) || data.length == 21 || data.length == 22 || data.length == 49)
-                && data[0] > 0x04
-        );
 
         vm.expectRevert(InvalidAddress.selector);
         FilAddresses.fromBytes(data);

--- a/contracts/v0.8/utils/FilAddresses.sol
+++ b/contracts/v0.8/utils/FilAddresses.sol
@@ -79,7 +79,7 @@ library FilAddresses {
     /// @return whether the address is valid or not
     function validate(CommonTypes.FilAddress memory addr) internal pure returns (bool) {
         if (addr.data[0] == 0x00) {
-            return addr.data.length <= 10;
+            return addr.data.length <= 11;
         } else if (addr.data[0] == 0x01 || addr.data[0] == 0x02) {
             return addr.data.length == 21;
         } else if (addr.data[0] == 0x03) {

--- a/contracts/v0.8/utils/FilAddresses.sol
+++ b/contracts/v0.8/utils/FilAddresses.sol
@@ -79,13 +79,13 @@ library FilAddresses {
     /// @return whether the address is valid or not
     function validate(CommonTypes.FilAddress memory addr) internal pure returns (bool) {
         if (addr.data[0] == 0x00) {
-            return addr.data.length <= 11;
+            return (addr.data.length > 1 && addr.data.length <= 11);
         } else if (addr.data[0] == 0x01 || addr.data[0] == 0x02) {
             return addr.data.length == 21;
         } else if (addr.data[0] == 0x03) {
             return addr.data.length == 49;
-        } else if (addr.data[0] == 0x04) {
-            return addr.data.length <= 64;
+        } else if (addr.data[0] == 0x04 && addr.data[1] == 0x0a) {
+            return addr.data.length == 22;
         }
 
         return false;

--- a/contracts/v0.8/utils/FilAddresses.sol
+++ b/contracts/v0.8/utils/FilAddresses.sol
@@ -39,11 +39,17 @@ library FilAddresses {
     /// @notice allow to get a eth address from 040a type FilAddress made above
     /// @param addr FilAddress to convert
     /// @return new eth address
-    function toEthAddress(CommonTypes.FilAddress calldata addr) internal pure returns (address) {
+    function toEthAddress(CommonTypes.FilAddress memory addr) internal pure returns (address) {
         if (addr.data[0] != 0x04 || addr.data[1] != 0x0a || addr.data.length != 22) {
             revert InvalidAddress();
         }
-        bytes20 ethAddress = bytes20(bytes(addr.data)[2:]);
+        bytes memory filAddress = addr.data;
+        bytes20 ethAddress;
+
+        assembly {
+            ethAddress := mload(add(filAddress, 0x22))
+        }
+
         return address(ethAddress);
     }
 
@@ -68,7 +74,7 @@ library FilAddresses {
     }
 
     /// @notice allow to validate if an address is valid or not
-    /// @dev we are only validating known address types. If the type is not known, the default value is true
+    /// @dev we are only validating known address types. If the type is not known, the default value is false
     /// @param addr the filecoin address to validate
     /// @return whether the address is valid or not
     function validate(CommonTypes.FilAddress memory addr) internal pure returns (bool) {
@@ -82,6 +88,6 @@ library FilAddresses {
             return addr.data.length <= 64;
         }
 
-        return addr.data.length <= 256;
+        return false;
     }
 }

--- a/contracts/v0.8/utils/FilAddresses.sol
+++ b/contracts/v0.8/utils/FilAddresses.sol
@@ -74,7 +74,7 @@ library FilAddresses {
     }
 
     /// @notice allow to validate if an address is valid or not
-    /// @dev we are only validating known address types. If the type is not known, the default value is false
+    /// @dev we are only validating known address types. If the type is not known, the default value is true
     /// @param addr the filecoin address to validate
     /// @return whether the address is valid or not
     function validate(CommonTypes.FilAddress memory addr) internal pure returns (bool) {
@@ -88,6 +88,6 @@ library FilAddresses {
             return addr.data.length == 22;
         }
 
-        return false;
+        return addr.data.length <= 256;
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,7 +8,6 @@ cache_path = 'foundry-cache'
 optimizer = true
 evm_version = 'paris'
 
-
 [fuzz]
 runs = 200
 


### PR DESCRIPTION
### Description

This pull request adds the required functionality related to issue [#4](https://github.com/filecoin-project/filecoin-solidity/issues/4)

Developers can utilize this function to convert a f4 FileAddress type into an EthAddress.

### Approach and implementation

The starting point was PR [#16](https://github.com/filecoin-project/filecoin-solidity/pull/16) which already included the implementation of this function. However, unit tests for various types of addresses were missing. The missing unit tests are added while retaining the existing fuzz tests with minor changes.

### Validate function changes

The ```validate``` function checks the FilAddress in bytes format, which includes a protocol byte and payload.

The previous implementation was failing for valid input because it was comparing the bytes length with 10:

```solidity
if (addr.data[0] == 0x00) {
    return addr.data.length <= 10; // should be <= 11 
}
```
This approach is incorrect, as the f0 format contains a protocol byte and payload, which can be a maximum of 10 bytes long. An example is provided in the Filecoin spec document, in the last example in section [6.1.3.1.](https://spec.filecoin.io/#section-appendix.address.id-type-addresses)
```
|----------|---------------|
| protocol |    payload    |
|----------|---------------|
|    0     | leb128-varint |
```

#### Discussion

- Should the ```validate``` function also include checks for minimum length for f0 and f4 addresses? For example, should 0x00 be considered a valid f0 address?
- Should f4 addresses be checked against a length of 65 if the payload is hardcoded to 54, as specified in [FIP](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0048.md#specification). If the payload is not 64 - prefix.len(), the total length, according to the format, should be 65 bytes. More details can be found in this [discussion](https://github.com/filecoin-project/FIPs/discussions/459#discussioncomment-3648766)
```
|------------|----------------|---------------------|
|  protocol  |      actor     |      payload        | 
|------------|----------------|---------------------|
|     04     |  leb128-variant|      54 bytes       |
```

### Affected issues
- Closes #4 