### PR TITLE
TypeConstructor.sol 

### DIFF
--- a/contracts/v0.8/tests/typeconstructor.test.sol
+++ b/contracts/v0.8/tests/typeconstructor.test.sol
@@ -6,11 +6,14 @@ import {CommonTypes} from "contracts/v0.8/types/CommonTypes.sol";
 import {TypeConstructor} from "contracts/v0.8/utils/TypeConstructor.sol";
 
 contract TypeConstructorTest is Test {
+    uint constant MAX_INVALID_DEAL_LABEL_LENGTH = 33554177; // test environment limit
+
     error InvalidLength();
 
     // UNIT TESTS
     function test_dealLabelFromBytes() external {
-        bytes memory data = bytes("test");
+        bytes memory data =
+            hex"6d41584367354149676d744a71377968314a5473474a6b50724131684c61536e585a49452b4d66656550316254384f4f47623441";
 
         CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromBytes(data);
 
@@ -19,31 +22,33 @@ contract TypeConstructorTest is Test {
     }
 
     function test_dealLabelFromBytesInvalidInput() external {
-        bytes memory data = new bytes(257);
+        bytes memory data = new bytes(CommonTypes.MAX_DEAL_LABEL_LENGTH + 1);
 
         vm.expectRevert(InvalidLength.selector);
         TypeConstructor.dealLabelFromBytes(data);
     }
 
     function test_dealLabelFromString() external {
-        string memory data = "test";
+        string memory data = "mAXCg5AIg8YBXbFjtdBy1iZjpDYAwRSt0elGLF5GvTqulEii1VcM";
+        bytes memory expectedValue =
+            hex"6d41584367354149673859425862466a7464427931695a6a704459417752537430656c474c463547765471756c4569693156634d";
 
         CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromString(data);
 
-        assertEq(label.data, bytes(data));
+        assertEq(label.data, expectedValue);
         assertEq(label.isString, true);
     }
 
     function test_dealLabelFromStringInvalidInput() external {
-        string memory data = new string(257);
+        string memory data = new string(CommonTypes.MAX_DEAL_LABEL_LENGTH + 1);
 
         vm.expectRevert(InvalidLength.selector);
         TypeConstructor.dealLabelFromString(data);
     }
-    
+
     // FUZZING TESTS
     function testFuzz_dealLabelFromBytes(bytes memory data) external {
-        vm.assume(data.length <= 256);
+        vm.assume(data.length <= CommonTypes.MAX_DEAL_LABEL_LENGTH);
 
         CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromBytes(data);
 
@@ -52,7 +57,7 @@ contract TypeConstructorTest is Test {
     }
 
     function testFuzz_dealLabelFromBytesInvalidLength(uint256 length) external {
-        vm.assume(length > 256 && length < 33554177);
+        vm.assume(length > CommonTypes.MAX_DEAL_LABEL_LENGTH && length < MAX_INVALID_DEAL_LABEL_LENGTH);
 
         bytes memory data = new bytes(length);
 
@@ -61,7 +66,7 @@ contract TypeConstructorTest is Test {
     }
 
     function testFuzz_dealLabelFromString(string memory data) external {
-        vm.assume(bytes(data).length <= 256);
+        vm.assume(bytes(data).length <= CommonTypes.MAX_DEAL_LABEL_LENGTH);
 
         CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromString(data);
 
@@ -70,7 +75,7 @@ contract TypeConstructorTest is Test {
     }
 
     function testFuzz_dealLabelFromStringInvalidLength(uint256 length) external {
-        vm.assume(length > 256 && length < 33554177);
+        vm.assume(length > CommonTypes.MAX_DEAL_LABEL_LENGTH && length < MAX_INVALID_DEAL_LABEL_LENGTH);
 
         string memory data = new string(length);
 

--- a/contracts/v0.8/tests/typeconstructor.test.sol
+++ b/contracts/v0.8/tests/typeconstructor.test.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {CommonTypes} from "contracts/v0.8/types/CommonTypes.sol";
+import {TypeConstructor} from "contracts/v0.8/utils/TypeConstructor.sol";
+
+contract TypeConstructorTest is Test {
+    error InvalidLength();
+
+    // UNIT TESTS
+    function test_dealLabelFromBytes() external {
+        bytes memory data = bytes("test");
+
+        CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromBytes(data);
+
+        assertEq(label.data, data);
+        assertEq(label.isString, false);
+    }
+
+    function test_dealLabelFromBytesInvalidInput() external {
+        bytes memory data = new bytes(257);
+
+        vm.expectRevert(InvalidLength.selector);
+        TypeConstructor.dealLabelFromBytes(data);
+    }
+
+    function test_dealLabelFromString() external {
+        string memory data = "test";
+
+        CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromString(data);
+
+        assertEq(label.data, bytes(data));
+        assertEq(label.isString, true);
+    }
+
+    function test_dealLabelFromStringInvalidInput() external {
+        string memory data = new string(257);
+
+        vm.expectRevert(InvalidLength.selector);
+        TypeConstructor.dealLabelFromString(data);
+    }
+    
+    // FUZZING TESTS
+    function testFuzz_dealLabelFromBytes(bytes memory data) external {
+        vm.assume(data.length <= 256);
+
+        CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromBytes(data);
+
+        assertEq(label.data, data);
+        assertEq(label.isString, false);
+    }
+
+    function testFuzz_dealLabelFromBytesInvalidLength(uint256 length) external {
+        vm.assume(length > 256 && length < 33554177);
+
+        bytes memory data = new bytes(length);
+
+        vm.expectRevert(InvalidLength.selector);
+        TypeConstructor.dealLabelFromBytes(data);
+    }
+
+    function testFuzz_dealLabelFromString(string memory data) external {
+        vm.assume(bytes(data).length <= 256);
+
+        CommonTypes.DealLabel memory label = TypeConstructor.dealLabelFromString(data);
+
+        assertEq(label.data, bytes(data));
+        assertEq(label.isString, true);
+    }
+
+    function testFuzz_dealLabelFromStringInvalidLength(uint256 length) external {
+        vm.assume(length > 256 && length < 33554177);
+
+        string memory data = new string(length);
+
+        vm.expectRevert(InvalidLength.selector);
+        TypeConstructor.dealLabelFromString(data);
+    }
+}

--- a/contracts/v0.8/types/CommonTypes.sol
+++ b/contracts/v0.8/types/CommonTypes.sol
@@ -24,7 +24,8 @@ pragma solidity ^0.8.17;
 /// @author Zondax AG
 library CommonTypes {
     uint constant UniversalReceiverHookMethodNum = 3726118371;
-
+    uint constant MAX_DEAL_LABEL_LENGTH = 256;
+    
     /// @param idx index for the failure in batch
     /// @param code failure code
     struct FailCode {

--- a/contracts/v0.8/utils/TypeConstructor.sol
+++ b/contracts/v0.8/utils/TypeConstructor.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "../types/CommonTypes.sol";
+
+/// @title TypeConstructor
+/// @notice This library is a set a functions that allows to construct filecoin common types from solidity
+/// @author Filecoin Project
+library TypeConstructor {
+    error InvalidLength();
+
+    /// @notice Converts a string to a filecoin cid common type
+    /// @param cid The CIDv1/CIDv0 cid string
+    function cidToBytes(string calldata cid) external pure returns (CommonTypes.Cid memory) {}
+
+    /// @notice Converts bytes to filecoin common type DealLabel
+    /// @param data The data must be no longer than 32 bytes
+    function bytesToDealLabel(bytes calldata data) external pure returns (CommonTypes.DealLabel memory) {
+        if (data.length > 32) {
+            revert InvalidLength();
+        }
+        return CommonTypes.DealLabel(data, false);
+    }
+
+    /// @notice Converts a string to filecoin common type DealLabel
+    /// @param data UTF-8 string
+    function stringToDealLabel(string calldata data) external pure returns (CommonTypes.DealLabel memory) {}
+}

--- a/contracts/v0.8/utils/TypeConstructor.sol
+++ b/contracts/v0.8/utils/TypeConstructor.sol
@@ -7,22 +7,23 @@ import "../types/CommonTypes.sol";
 /// @notice This library is a set a functions that allows to construct filecoin common types from solidity
 /// @author Filecoin Project
 library TypeConstructor {
+
     error InvalidLength();
 
     /// @notice Converts bytes to filecoin common type DealLabel
-    /// @param data The data must be no longer than 256 bytes
+    /// @param data The data must be no longer than MAX_DEAL_LABEL_LENGTH bytes
     function dealLabelFromBytes(bytes memory data) internal pure returns (CommonTypes.DealLabel memory) {
-        if (data.length > 256) {
+        if (data.length > CommonTypes.MAX_DEAL_LABEL_LENGTH) {
             revert InvalidLength();
         }
         return CommonTypes.DealLabel(data, false);
     }
 
     /// @notice Converts a string to filecoin common type DealLabel
-    /// @param data UTF-8 string, must be no longer than 256 bytes when encoded
+    /// @param data UTF-8 string, must be no longer MAX_DEAL_LABEL_LENGTH bytes when encoded
     function dealLabelFromString(string memory data) internal pure returns (CommonTypes.DealLabel memory) {
         bytes memory dataBytes = bytes(data);
-        if (dataBytes.length > 256) {
+        if (dataBytes.length > CommonTypes.MAX_DEAL_LABEL_LENGTH) {
             revert InvalidLength();
         }
         return CommonTypes.DealLabel(dataBytes, true);

--- a/contracts/v0.8/utils/TypeConstructor.sol
+++ b/contracts/v0.8/utils/TypeConstructor.sol
@@ -9,20 +9,22 @@ import "../types/CommonTypes.sol";
 library TypeConstructor {
     error InvalidLength();
 
-    /// @notice Converts a string to a filecoin cid common type
-    /// @param cid The CIDv1/CIDv0 cid string
-    function cidToBytes(string calldata cid) external pure returns (CommonTypes.Cid memory) {}
-
     /// @notice Converts bytes to filecoin common type DealLabel
-    /// @param data The data must be no longer than 32 bytes
-    function bytesToDealLabel(bytes calldata data) external pure returns (CommonTypes.DealLabel memory) {
-        if (data.length > 32) {
+    /// @param data The data must be no longer than 256 bytes
+    function dealLabelFromBytes(bytes memory data) internal pure returns (CommonTypes.DealLabel memory) {
+        if (data.length > 256) {
             revert InvalidLength();
         }
         return CommonTypes.DealLabel(data, false);
     }
 
     /// @notice Converts a string to filecoin common type DealLabel
-    /// @param data UTF-8 string
-    function stringToDealLabel(string calldata data) external pure returns (CommonTypes.DealLabel memory) {}
+    /// @param data UTF-8 string, must be no longer than 256 bytes when encoded
+    function dealLabelFromString(string memory data) internal pure returns (CommonTypes.DealLabel memory) {
+        bytes memory dataBytes = bytes(data);
+        if (dataBytes.length > 256) {
+            revert InvalidLength();
+        }
+        return CommonTypes.DealLabel(dataBytes, true);
+    }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ test = 'contracts/v0.8/test'
 cache_path = 'foundry-cache'
 optimizer = true
 evm_version = 'paris'
-auto_detect_remappings = false
+
 
 [fuzz]
 runs = 200


### PR DESCRIPTION
### Description

This pull request proposes the required functionality related to issue [#5](https://github.com/filecoin-project/filecoin-solidity/issues/5) 

It will allow developers who integrate the filecoin-solidity library into their codebase to construct common Filecoin types. Some of the types are not intended to be created by developers, such as FailCode, BatchReturn, etc. For other common types like BigInt and FilAddress, there are already methods that allow conversion to these types.

### Proposed functions
```solidity
    function dealLabelFromBytes(bytes calldata data) internal pure returns (CommonTypes.DealLabel memory) {}
    function dealLabelFromString(string calldata data) internal pure returns (CommonTypes.DealLabel memory) {}
```

### Affected issues
- Closes #5 