### PR TITLE
Issue #26 Proposal

### DIFF
--- a/contracts/v0.8/MinerAPI.sol
+++ b/contracts/v0.8/MinerAPI.sol
@@ -142,15 +142,13 @@ library MinerAPI {
     /// @param target The miner actor id you want to interact with
     /// @return exit code (!= 0) if an error occured, 0 otherwise
     /// @return the funds vesting in this miner as a list of (vesting_epoch, vesting_amount) tuples.
-    function getVestingFunds(CommonTypes.FilActorId target) internal view returns (int256, MinerTypes.GetVestingFundsReturn memory) {
+    function getVestingFunds(CommonTypes.FilActorId target) internal view returns (int256, MinerTypes.VestingFunds[] memory) {
         bytes memory raw_request = new bytes(0);
-
         (int256 exit_code, bytes memory result) = Actor.callNonSingletonByIDReadOnly(target, MinerTypes.GetVestingFundsMethodNum, Misc.NONE_CODEC, raw_request);
         if (exit_code == 0) {
             return (0, result.deserializeGetVestingFundsReturn());
         }
-
-        MinerTypes.GetVestingFundsReturn memory empty_res;
+        MinerTypes.VestingFunds[] memory empty_res;
         return (exit_code, empty_res);
     }
 

--- a/contracts/v0.8/MinerAPI.sol
+++ b/contracts/v0.8/MinerAPI.sol
@@ -227,8 +227,8 @@ library MinerAPI {
 
     /// @param target The miner actor id you want to interact with
     /// @return exit code (!= 0) if an error occured, 0 otherwise
-    function changeMultiaddresses(CommonTypes.FilActorId target, MinerTypes.ChangeMultiaddrsParams memory params) internal returns (int256) {
-        bytes memory raw_request = params.serializeChangeMultiaddrsParams();
+    function changeMultiaddresses(CommonTypes.FilActorId target, CommonTypes.FilAddress[] memory new_multi_addrs) internal returns (int256) {
+        bytes memory raw_request = new_multi_addrs.serializeChangeMultiaddrsParams();
 
         (int256 exit_code, bytes memory result) = Actor.callNonSingletonByID(
             target,

--- a/contracts/v0.8/MinerAPI.sol
+++ b/contracts/v0.8/MinerAPI.sol
@@ -297,7 +297,7 @@ library MinerAPI {
     /// @param target The miner actor id you want to interact with
     /// @return exit code (!= 0) if an error occured, 0 otherwise
     /// @return multiaddresses for `target`
-    function getMultiaddresses(CommonTypes.FilActorId target) internal view returns (int256, MinerTypes.GetMultiaddrsReturn memory) {
+    function getMultiaddresses(CommonTypes.FilActorId target) internal view returns (int256, CommonTypes.FilAddress[] memory) {
         bytes memory raw_request = new bytes(0);
 
         (int256 exit_code, bytes memory result) = Actor.callNonSingletonByIDReadOnly(target, MinerTypes.GetMultiaddrsMethodNum, Misc.NONE_CODEC, raw_request);
@@ -305,7 +305,7 @@ library MinerAPI {
             return (0, result.deserializeGetMultiaddrsReturn());
         }
 
-        MinerTypes.GetMultiaddrsReturn memory empty_res;
+        CommonTypes.FilAddress[] memory empty_res;
         return (exit_code, empty_res);
     }
 

--- a/contracts/v0.8/VerifRegAPI.sol
+++ b/contracts/v0.8/VerifRegAPI.sol
@@ -93,9 +93,8 @@ library VerifRegAPI {
 
     /// @notice extends the  maximum term of some claims up to the largest value they could have been originally allocated. This method can only be called by the claims' client.
     /// @return exit code (!= 0) if an error occured, 0 otherwise
-    function extendClaimTerms(VerifRegTypes.ExtendClaimTermsParams memory params) internal returns (int256, CommonTypes.BatchReturn memory) {
-        bytes memory raw_request = params.serializeExtendClaimTermsParams();
-
+    function extendClaimTerms(VerifRegTypes.ClaimTerm[] memory claimTerms) internal returns (int256, CommonTypes.BatchReturn memory) {
+        bytes memory raw_request = claimTerms.serializeExtendClaimTermsParams();
         (int256 exit_code, bytes memory result) = Actor.callByID(
             VerifRegTypes.ActorID,
             VerifRegTypes.ExtendClaimTermsMethodNum,
@@ -104,11 +103,9 @@ library VerifRegAPI {
             0,
             false
         );
-
         if (exit_code == 0) {
             return (0, result.deserializeBatchReturn());
         }
-
         CommonTypes.BatchReturn memory empty_res;
         return (exit_code, empty_res);
     }

--- a/contracts/v0.8/cbor/MinerCbor.sol
+++ b/contracts/v0.8/cbor/MinerCbor.sol
@@ -230,7 +230,5 @@ library MinerCBOR {
         for (uint i = 0; i < len; i++) {
             (multi_addrs[i].data, byteIdx) = rawResp.readBytes(byteIdx);
         }
-
-        return multi_addrs;
     }
 }

--- a/contracts/v0.8/cbor/MinerCbor.sol
+++ b/contracts/v0.8/cbor/MinerCbor.sol
@@ -192,23 +192,23 @@ library MinerCBOR {
     }
 
     /// @notice serialize ChangeMultiaddrsParams struct to cbor in order to pass as arguments to the miner actor
-    /// @param params ChangeMultiaddrsParams to serialize as cbor
+    /// @param new_multi_addrs ChangeMultiaddrsParams to serialize as cbor
     /// @return cbor serialized data as bytes
-    function serializeChangeMultiaddrsParams(MinerTypes.ChangeMultiaddrsParams memory params) internal pure returns (bytes memory) {
+    function serializeChangeMultiaddrsParams(CommonTypes.FilAddress[] memory new_multi_addrs) internal pure returns (bytes memory) {
         uint256 capacity = 0;
 
         capacity += Misc.getPrefixSize(1);
-        capacity += Misc.getPrefixSize(uint256(params.new_multi_addrs.length));
-        for (uint64 i = 0; i < params.new_multi_addrs.length; i++) {
-            capacity += Misc.getBytesSize(params.new_multi_addrs[i].data);
+        capacity += Misc.getPrefixSize(uint256(new_multi_addrs.length));
+        for (uint64 i = 0; i < new_multi_addrs.length; i++) {
+            capacity += Misc.getBytesSize(new_multi_addrs[i].data);
         }
         CBOR.CBORBuffer memory buf = CBOR.create(capacity);
 
         buf.startFixedArray(1);
-        buf.startFixedArray(uint64(params.new_multi_addrs.length));
+        buf.startFixedArray(uint64(new_multi_addrs.length));
 
-        for (uint64 i = 0; i < params.new_multi_addrs.length; i++) {
-            buf.writeBytes(params.new_multi_addrs[i].data);
+        for (uint64 i = 0; i < new_multi_addrs.length; i++) {
+            buf.writeBytes(new_multi_addrs[i].data);
         }
 
         return buf.data();

--- a/contracts/v0.8/cbor/MinerCbor.sol
+++ b/contracts/v0.8/cbor/MinerCbor.sol
@@ -216,8 +216,8 @@ library MinerCBOR {
 
     /// @notice deserialize GetMultiaddrsReturn struct from cbor encoded bytes coming from a miner actor call
     /// @param rawResp cbor encoded response
-    /// @return ret new instance of GetMultiaddrsReturn created based on parsed data
-    function deserializeGetMultiaddrsReturn(bytes memory rawResp) internal pure returns (MinerTypes.GetMultiaddrsReturn memory ret) {
+    /// @return multi_addrs deserialized addresses
+    function deserializeGetMultiaddrsReturn(bytes memory rawResp) internal pure returns (CommonTypes.FilAddress[] memory multi_addrs) {
         uint byteIdx = 0;
         uint len;
 
@@ -225,12 +225,12 @@ library MinerCBOR {
         assert(len == 1);
 
         (len, byteIdx) = rawResp.readFixedArray(byteIdx);
-        ret.multi_addrs = new CommonTypes.FilAddress[](len);
+        multi_addrs = new CommonTypes.FilAddress[](len);
 
         for (uint i = 0; i < len; i++) {
-            (ret.multi_addrs[i].data, byteIdx) = rawResp.readBytes(byteIdx);
+            (multi_addrs[i].data, byteIdx) = rawResp.readBytes(byteIdx);
         }
 
-        return ret;
+        return multi_addrs;
     }
 }

--- a/contracts/v0.8/cbor/MinerCbor.sol
+++ b/contracts/v0.8/cbor/MinerCbor.sol
@@ -138,8 +138,8 @@ library MinerCBOR {
 
     /// @notice deserialize GetVestingFundsReturn struct from cbor encoded bytes coming from a miner actor call
     /// @param rawResp cbor encoded response
-    /// @return ret new instance of GetVestingFundsReturn created based on parsed data
-    function deserializeGetVestingFundsReturn(bytes memory rawResp) internal pure returns (MinerTypes.GetVestingFundsReturn memory ret) {
+    /// @return vesting_funds new instance of GetVestingFundsReturn created based on parsed data
+    function deserializeGetVestingFundsReturn(bytes memory rawResp) internal pure returns (MinerTypes.VestingFunds[] memory vesting_funds) {
         CommonTypes.ChainEpoch epoch;
         CommonTypes.BigInt memory amount;
         bytes memory tmp;
@@ -152,7 +152,7 @@ library MinerCBOR {
         assert(len == 1);
 
         (len, byteIdx) = rawResp.readFixedArray(byteIdx);
-        ret.vesting_funds = new MinerTypes.VestingFunds[](len);
+        vesting_funds = new MinerTypes.VestingFunds[](len);
 
         for (uint i = 0; i < len; i++) {
             (leni, byteIdx) = rawResp.readFixedArray(byteIdx);
@@ -162,10 +162,8 @@ library MinerCBOR {
             (tmp, byteIdx) = rawResp.readBytes(byteIdx);
 
             amount = tmp.deserializeBigInt();
-            ret.vesting_funds[i] = MinerTypes.VestingFunds(epoch, amount);
+            vesting_funds[i] = MinerTypes.VestingFunds(epoch, amount);
         }
-
-        return ret;
     }
 
     /// @notice serialize ChangeWorkerAddressParams struct to cbor in order to pass as arguments to the miner actor

--- a/contracts/v0.8/cbor/VerifRegCbor.sol
+++ b/contracts/v0.8/cbor/VerifRegCbor.sol
@@ -194,18 +194,18 @@ library VerifRegCBOR {
     }
 
     /// @notice serialize ExtendClaimTermsParams struct to cbor in order to pass as arguments to the verified registry actor
-    /// @param params ExtendClaimTermsParams to serialize as cbor
+    /// @param terms ExtendClaimTermsParams to serialize as cbor
     /// @return cbor serialized data as bytes
-    function serializeExtendClaimTermsParams(VerifRegTypes.ExtendClaimTermsParams memory params) internal pure returns (bytes memory) {
+    function serializeExtendClaimTermsParams(VerifRegTypes.ClaimTerm[] memory terms) internal pure returns (bytes memory) {
         uint256 capacity = 0;
-        uint termsLen = params.terms.length;
+        uint termsLen = terms.length;
 
         capacity += Misc.getPrefixSize(1);
         capacity += Misc.getPrefixSize(termsLen);
         for (uint i = 0; i < termsLen; i++) {
-            capacity += Misc.getFilActorIdSize(params.terms[i].provider);
-            capacity += Misc.getFilActorIdSize(params.terms[i].claim_id);
-            capacity += Misc.getChainEpochSize(params.terms[i].term_max);
+            capacity += Misc.getFilActorIdSize(terms[i].provider);
+            capacity += Misc.getFilActorIdSize(terms[i].claim_id);
+            capacity += Misc.getChainEpochSize(terms[i].term_max);
         }
         CBOR.CBORBuffer memory buf = CBOR.create(capacity);
 
@@ -213,9 +213,9 @@ library VerifRegCBOR {
         buf.startFixedArray(uint64(termsLen));
         for (uint i = 0; i < termsLen; i++) {
             buf.startFixedArray(3);
-            buf.writeFilActorId(params.terms[i].provider);
-            buf.writeFilActorId(params.terms[i].claim_id);
-            buf.writeChainEpoch(params.terms[i].term_max);
+            buf.writeFilActorId(terms[i].provider);
+            buf.writeFilActorId(terms[i].claim_id);
+            buf.writeChainEpoch(terms[i].term_max);
         }
 
         return buf.data();

--- a/contracts/v0.8/mocks/MinerMockAPI.sol
+++ b/contracts/v0.8/mocks/MinerMockAPI.sol
@@ -90,11 +90,11 @@ contract MinerMockAPI {
     }
 
     /// @return the funds vesting in this miner as a list of (vesting_epoch, vesting_amount) tuples.
-    function getVestingFunds() public pure returns (MinerTypes.GetVestingFundsReturn memory) {
+    function getVestingFunds() public pure returns (MinerTypes.VestingFunds[] memory) {
         MinerTypes.VestingFunds[] memory vesting_funds = new MinerTypes.VestingFunds[](1);
         vesting_funds[0] = MinerTypes.VestingFunds(CommonTypes.ChainEpoch.wrap(1668514825), CommonTypes.BigInt(hex"6C6B935B8BBD400000", false));
 
-        return MinerTypes.GetVestingFundsReturn(vesting_funds);
+        return vesting_funds;
     }
 
     /// @notice Proposes or confirms a change of beneficiary address.

--- a/contracts/v0.8/tests/account.test.sol
+++ b/contracts/v0.8/tests/account.test.sol
@@ -36,7 +36,7 @@ contract AccountApiTest {
     }
 
     function universal_receiver_hook(CommonTypes.FilActorId target, CommonTypes.UniversalReceiverParams memory params) public {
-        (int256 exit_code, bytes memory result) = Utils.universalReceiverHook(target, params);
+        (int256 exit_code, ) = Utils.universalReceiverHook(target, params);
 
         Errors.revertOnError(exit_code);
     }

--- a/contracts/v0.8/tests/deserializeparams.test.sol
+++ b/contracts/v0.8/tests/deserializeparams.test.sol
@@ -30,8 +30,8 @@ contract DeserializeParamsTest {
     function deserializeGetVestingFundsReturn() public pure {
         bytes memory params = hex"8181820040";
 
-        MinerTypes.GetVestingFundsReturn memory result = params.deserializeGetVestingFundsReturn();
+        MinerTypes.VestingFunds[] memory vesting_funds = params.deserializeGetVestingFundsReturn();
 
-        require(result.vesting_funds.length == 1, "result length should be 1");
+        require(vesting_funds.length == 1, "result length should be 1");
     }
 }

--- a/contracts/v0.8/tests/market.test.sol
+++ b/contracts/v0.8/tests/market.test.sol
@@ -30,7 +30,7 @@ contract MarketApiTest {
     uint[] public publishedDealIds;
 
     function add_balance(CommonTypes.FilAddress memory providerOrClient, uint256 value) public payable {
-        (int256 exit_code, bytes memory result) = MarketAPI.addBalance(providerOrClient, value);
+        (int256 exit_code, ) = MarketAPI.addBalance(providerOrClient, value);
 
         Errors.revertOnError(exit_code);
     }

--- a/contracts/v0.8/tests/miner.test.sol
+++ b/contracts/v0.8/tests/miner.test.sol
@@ -123,8 +123,8 @@ contract MinerApiTest {
         return result;
     }
 
-    function get_multiaddresses(CommonTypes.FilActorId target) public view returns (MinerTypes.GetMultiaddrsReturn memory) {
-        (int256 exit_code, MinerTypes.GetMultiaddrsReturn memory result) = MinerAPI.getMultiaddresses(target);
+    function get_multiaddresses(CommonTypes.FilActorId target) public view returns (CommonTypes.FilAddress[] memory) {
+        (int256 exit_code, CommonTypes.FilAddress[] memory result) = MinerAPI.getMultiaddresses(target);
 
         Errors.revertOnError(exit_code);
 

--- a/contracts/v0.8/tests/miner.test.sol
+++ b/contracts/v0.8/tests/miner.test.sol
@@ -65,11 +65,9 @@ contract MinerApiTest {
         return result;
     }
 
-    function get_vesting_funds(CommonTypes.FilActorId target) public view returns (MinerTypes.GetVestingFundsReturn memory) {
-        (int256 exit_code, MinerTypes.GetVestingFundsReturn memory result) = MinerAPI.getVestingFunds(target);
-
+    function get_vesting_funds(CommonTypes.FilActorId target) public view returns (MinerTypes.VestingFunds[] memory) {
+        (int256 exit_code, MinerTypes.VestingFunds[] memory result) = MinerAPI.getVestingFunds(target);
         Errors.revertOnError(exit_code);
-
         return result;
     }
 

--- a/contracts/v0.8/tests/miner.test.sol
+++ b/contracts/v0.8/tests/miner.test.sol
@@ -97,8 +97,8 @@ contract MinerApiTest {
         Errors.revertOnError(exit_code);
     }
 
-    function change_multiaddresses(CommonTypes.FilActorId target, MinerTypes.ChangeMultiaddrsParams memory params) public {
-        int256 exit_code = MinerAPI.changeMultiaddresses(target, params);
+    function change_multiaddresses(CommonTypes.FilActorId target, CommonTypes.FilAddress[] memory new_multi_addrs) public {
+        int256 exit_code = MinerAPI.changeMultiaddresses(target, new_multi_addrs);
 
         Errors.revertOnError(exit_code);
     }

--- a/contracts/v0.8/tests/verifreg.test.sol
+++ b/contracts/v0.8/tests/verifreg.test.sol
@@ -52,11 +52,9 @@ contract VerifRegApiTest {
         return result;
     }
 
-    function extend_claim_terms(VerifRegTypes.ExtendClaimTermsParams memory params) public returns (CommonTypes.BatchReturn memory) {
-        (int256 exit_code, CommonTypes.BatchReturn memory result) = VerifRegAPI.extendClaimTerms(params);
-
+    function extend_claim_terms(VerifRegTypes.ClaimTerm[] memory claimTerms) public returns (CommonTypes.BatchReturn memory) {
+        (int256 exit_code, CommonTypes.BatchReturn memory result) = VerifRegAPI.extendClaimTerms(claimTerms);
         Errors.revertOnError(exit_code);
-
         return result;
     }
 

--- a/contracts/v0.8/types/MinerTypes.sol
+++ b/contracts/v0.8/types/MinerTypes.sol
@@ -72,16 +72,6 @@ library MinerTypes {
         CommonTypes.FilAddress[] new_control_addresses;
     }
 
-    /// @param new_multi_addrs the new multi-signature address.
-    struct ChangeMultiaddrsParams {
-        CommonTypes.FilAddress[] new_multi_addrs;
-    }
-
-    /// @param multi_addrs the multi-signature address.
-    struct GetMultiaddrsReturn {
-        CommonTypes.FilAddress[] multi_addrs;
-    }
-
     /// @param epoch the epoch of funds vested.
     /// @param amount the amount of funds vested.
     struct VestingFunds {

--- a/contracts/v0.8/types/MinerTypes.sol
+++ b/contracts/v0.8/types/MinerTypes.sol
@@ -49,12 +49,6 @@ library MinerTypes {
         CommonTypes.FilAddress proposed;
     }
 
-    // Depracated
-    /// @param vesting_funds funds
-    // struct GetVestingFundsReturn {
-    //     VestingFunds[] vesting_funds;
-    // }
-
     /// @param new_beneficiary the new beneficiary address.
     /// @param new_quota the new quota token amount.
     /// @param new_expiration the epoch that the new quota will be expired.

--- a/contracts/v0.8/types/MinerTypes.sol
+++ b/contracts/v0.8/types/MinerTypes.sol
@@ -49,10 +49,11 @@ library MinerTypes {
         CommonTypes.FilAddress proposed;
     }
 
+    // Depracated
     /// @param vesting_funds funds
-    struct GetVestingFundsReturn {
-        VestingFunds[] vesting_funds;
-    }
+    // struct GetVestingFundsReturn {
+    //     VestingFunds[] vesting_funds;
+    // }
 
     /// @param new_beneficiary the new beneficiary address.
     /// @param new_quota the new quota token amount.

--- a/contracts/v0.8/types/VerifRegTypes.sol
+++ b/contracts/v0.8/types/VerifRegTypes.sol
@@ -83,11 +83,6 @@ library VerifRegTypes {
         CommonTypes.BatchReturn results;
     }
 
-    /// @param terms list of claim terms to extend
-    struct ExtendClaimTermsParams {
-        ClaimTerm[] terms;
-    }
-
     /// @param provider the provider address which storing the data.
     /// @param claim_id claim ID.
     /// @param term_max the max chain epoch to extend.

--- a/testing/Cargo.lock
+++ b/testing/Cargo.lock
@@ -3504,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724fd11728a3804e9944b14cab63825024c40bf42f8af87c8b5d97c4bbacf426"
+checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",

--- a/testing/src/api_contracts/miner_test.rs
+++ b/testing/src/api_contracts/miner_test.rs
@@ -101,4 +101,7 @@ sol!{
     function get_multiaddresses(FilActorId target) public returns (GetMultiaddrsReturn memory) {}
 
     function withdraw_balance(FilActorId target, BigInt memory amount) public returns (BigInt memory) {}
+
+    //helpers
+    function encode_vesting_funds(VestingFunds[] vesting_funds) public {}
 }

--- a/testing/src/api_contracts/miner_test.rs
+++ b/testing/src/api_contracts/miner_test.rs
@@ -102,4 +102,6 @@ sol!{
 
     //helpers
     function encode_vesting_funds(VestingFunds[] vesting_funds) public {}
+
+    function encode_multi_addrs(FilAddress[] multi_addrs) public {}
 }

--- a/testing/src/api_contracts/miner_test.rs
+++ b/testing/src/api_contracts/miner_test.rs
@@ -36,9 +36,7 @@ sol!{
         FilAddress[] new_control_addresses;
     }
 
-    struct ChangeMultiaddrsParams {
-        FilAddress[] new_multi_addrs;
-    }
+
 
     struct GetMultiaddrsReturn {
         FilAddress[] multi_addrs;
@@ -80,7 +78,7 @@ sol!{
 
     function get_available_balance(FilActorId target) public returns (BigInt memory) {}
 
-    function get_vesting_funds(FilActorId target) public returns (GetVestingFundsReturn memory) {}
+    function get_vesting_funds(FilActorId target) public returns (VestingFunds[] memory) {}
 
     function change_beneficiary(FilActorId target, ChangeBeneficiaryParams memory params) public {}
 
@@ -90,7 +88,7 @@ sol!{
 
     function change_peer_id(FilActorId target, FilAddress memory newId) public {}
 
-    function change_multiaddresses(FilActorId target, ChangeMultiaddrsParams memory params) public {}
+    function change_multiaddresses(FilActorId target, FilAddress[] memory new_multi_addrs) public {}
 
     function repay_debt(FilActorId target) public {}
 

--- a/testing/tests/miner.rs
+++ b/testing/tests/miner.rs
@@ -486,11 +486,8 @@ fn miner_tests() {
     gas_result.push(("get_vesting_funds".into(), gas_used));
     assert_eq!(res.msg_receipt.exit_code.value(), 0);
 
-    let expected_vesting_funds = api_contracts::miner_test::GetVestingFundsReturn{
-        vesting_funds: vec![]
-    };
-    let abi_encoded_call = api_contracts::miner_test::GetVestingFundsReturn::abi_encode(&expected_vesting_funds);
-    let cbor_encoded = api_contracts::cbor_encode(abi_encoded_call);
+    let abi_encoded_call = api_contracts::miner_test::encode_vesting_fundsCall{vesting_funds: vec![]}.abi_encode();
+    let cbor_encoded = api_contracts::cbor_encode(abi_encoded_call[4..].to_vec());
 
     assert_eq!(
         hex::encode(res.msg_receipt.return_data.bytes()), 

--- a/testing/tests/miner.rs
+++ b/testing/tests/miner.rs
@@ -762,13 +762,11 @@ fn miner_tests() {
 
     let abi_encoded_call = api_contracts::miner_test::change_multiaddressesCall{
         target: 0x66_u64,
-        params: api_contracts::miner_test::ChangeMultiaddrsParams{
-            new_multi_addrs: vec![
-                api_contracts::miner_test::FilAddress{
-                    data: vec![0_u8, 0x66]
-                }
-            ]
-        }
+        new_multi_addrs: vec![
+            api_contracts::miner_test::FilAddress{
+                data: vec![0_u8, 0x66]
+            }
+        ]
     }.abi_encode();
 
     let cbor_encoded = api_contracts::cbor_encode(abi_encoded_call);

--- a/testing/tests/miner.rs
+++ b/testing/tests/miner.rs
@@ -624,15 +624,14 @@ fn miner_tests() {
     gas_result.push(("get_multiaddresses".into(), gas_used));
     assert_eq!(res.msg_receipt.exit_code.value(), 0);
 
-    let expected_multi_addr = api_contracts::miner_test::GetMultiaddrsReturn{
-        multi_addrs: vec![
-            api_contracts::miner_test::FilAddress{
-                data: vec![1_u8, 2, 3]
-            }
-        ]
-    };
-    let abi_encoded_call = api_contracts::miner_test::GetMultiaddrsReturn::abi_encode(&expected_multi_addr);
-    let cbor_encoded = api_contracts::cbor_encode(abi_encoded_call);
+    let expected_multi_addr = vec![
+        api_contracts::miner_test::FilAddress{
+            data: vec![1_u8, 2, 3]
+        }
+    ];
+    
+    let abi_encoded_call = api_contracts::miner_test::encode_multi_addrsCall{multi_addrs: expected_multi_addr}.abi_encode();
+    let cbor_encoded = api_contracts::cbor_encode(abi_encoded_call[4..].to_vec());
 
     assert_eq!(
         hex::encode(res.msg_receipt.return_data.bytes()), 


### PR DESCRIPTION
### Description
The pull request aims to address issue [#26](https://github.com/filecoin-project/filecoin-solidity/issues/26). The current definition of the `GetDealTermReturn` struct is as follows:
```solidity
struct GetDealTermReturn {
        ChainEpoch start;
        ChainEpoch end;
    }
```
The `MarketAPI.getDealTerm()` method returns the start epoch and duration, but it stores the duration in the end field, which can be confusing and misrepresent the value.
### Proposed changes
The proposed changes include either altering the struct field name to `duration` or modifying the functionality in `getDealTerm()` to accurately represent the end epoch value.  Regardless of whether we choose to rename the field or modify the functionality, it's important to note that we will need to update relevant tests and affected files to align with this change.
### Affected issues
- Closes #26 