### PR TITLE
[M4] Remix IDE contract flattening fix

### DIFF
--- a/contracts/v0.8/tests/account.test.sol
+++ b/contracts/v0.8/tests/account.test.sol
@@ -22,7 +22,7 @@ pragma solidity ^0.8.17;
 import "../types/AccountTypes.sol";
 import "../types/CommonTypes.sol";
 import "../AccountAPI.sol";
-import "../utils/Misc.sol";
+import "../utils/UtilsHandlers.sol";
 import "../utils/Errors.sol";
 
 /// @notice This file is meant to serve as a deployable contract of the account actor API, as the library by itself is not.
@@ -36,7 +36,7 @@ contract AccountApiTest {
     }
 
     function universal_receiver_hook(CommonTypes.FilActorId target, CommonTypes.UniversalReceiverParams memory params) public {
-        (int256 exit_code, bytes memory result) = Misc.universalReceiverHook(target, params);
+        (int256 exit_code, bytes memory result) = UtilsHandlers.universalReceiverHook(target, params);
 
         Errors.revertOnError(exit_code);
     }

--- a/contracts/v0.8/tests/datacap.test.sol
+++ b/contracts/v0.8/tests/datacap.test.sol
@@ -23,7 +23,7 @@ import "../types/DataCapTypes.sol";
 import "../types/CommonTypes.sol";
 import "../cbor/BigIntCbor.sol";
 import "../DataCapAPI.sol";
-import "../utils/Misc.sol";
+import "../utils/UtilsHandlers.sol";
 import "../utils/Errors.sol";
 
 /// @notice This file is meant to serve as a deployable contract of the datacap actor API, as the library by itself is not.
@@ -127,6 +127,6 @@ contract DataCapApiTest {
     }
 
     function handle_filecoin_method(uint64 method, uint64 codec, bytes calldata params) public pure {
-        Misc.handleFilecoinMethod(method, codec, params);
+        UtilsHandlers.handleFilecoinMethod(method, codec, params);
     }
 }

--- a/contracts/v0.8/utils/Misc.sol
+++ b/contracts/v0.8/utils/Misc.sol
@@ -26,8 +26,6 @@ import "../cbor/AccountCbor.sol";
 import "../cbor/BytesCbor.sol";
 import "../cbor/FilecoinCbor.sol";
 
-import "../utils/Actor.sol";
-
 /// @title Library containing miscellaneous functions used on the project
 /// @author Zondax AG
 library Misc {
@@ -107,29 +105,5 @@ library Misc {
 
     function getBoolSize() internal pure returns (uint256) {
         return getPrefixSize(1);
-    }
-
-    /// @notice utility function meant to handle calls from other builtin actors. Arguments are passed as cbor serialized data (in filecoin native format)
-    /// @param method the filecoin method id that is being called
-    /// @param params raw data (in bytes) passed as arguments to the method call
-    function handleFilecoinMethod(uint64 method, uint64 codec, bytes calldata params) internal pure returns (CommonTypes.UniversalReceiverParams memory) {
-        if (method == CommonTypes.UniversalReceiverHookMethodNum) {
-            if (codec != Misc.CBOR_CODEC) {
-                revert InvalidCodec(codec);
-            }
-
-            return params.deserializeUniversalReceiverParams();
-        } else {
-            revert MethodNotHandled(method);
-        }
-    }
-
-    /// @param target The actor id you want to interact with
-    function universalReceiverHook(CommonTypes.FilActorId target, CommonTypes.UniversalReceiverParams memory params) internal returns (int256, bytes memory) {
-        bytes memory raw_request = params.serializeUniversalReceiverParams();
-
-        (int256 exit_code, bytes memory result) = Actor.callByID(target, CommonTypes.UniversalReceiverHookMethodNum, Misc.CBOR_CODEC, raw_request, 0, false);
-
-        return (exit_code, result);
     }
 }

--- a/contracts/v0.8/utils/Misc.sol
+++ b/contracts/v0.8/utils/Misc.sol
@@ -23,10 +23,6 @@ import "../types/CommonTypes.sol";
 /// @title Library containing miscellaneous functions used on the project
 /// @author Zondax AG
 library Misc {
-    // using AccountCBOR for *;
-    // using FilecoinCBOR for *;
-    // using BytesCBOR for bytes;
-
     /// @notice the codec received is not valid
     error InvalidCodec(uint64);
 

--- a/contracts/v0.8/utils/Misc.sol
+++ b/contracts/v0.8/utils/Misc.sol
@@ -19,19 +19,13 @@
 pragma solidity ^0.8.17;
 
 import "../types/CommonTypes.sol";
-import "../types/AccountTypes.sol";
-import "../types/DataCapTypes.sol";
-
-import "../cbor/AccountCbor.sol";
-import "../cbor/BytesCbor.sol";
-import "../cbor/FilecoinCbor.sol";
 
 /// @title Library containing miscellaneous functions used on the project
 /// @author Zondax AG
 library Misc {
-    using AccountCBOR for *;
-    using FilecoinCBOR for *;
-    using BytesCBOR for bytes;
+    // using AccountCBOR for *;
+    // using FilecoinCBOR for *;
+    // using BytesCBOR for bytes;
 
     /// @notice the codec received is not valid
     error InvalidCodec(uint64);

--- a/contracts/v0.8/utils/UtilsHandlers.sol
+++ b/contracts/v0.8/utils/UtilsHandlers.sol
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ *   (c) 2022 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+// THIS CODE WAS SECURITY REVIEWED BY KUDELSKI SECURITY, BUT NOT FORMALLY AUDITED
+
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.17;
+
+import "../types/CommonTypes.sol";
+import "../types/AccountTypes.sol";
+import "../types/DataCapTypes.sol";
+
+import "../cbor/AccountCbor.sol";
+import "../cbor/BytesCbor.sol";
+import "../cbor/FilecoinCbor.sol";
+
+import "../utils/Actor.sol";
+
+/// @title Library containing common handler functions used in the project
+/// @author Zondax AG
+library UtilsHandlers {
+    using AccountCBOR for *;
+    using FilecoinCBOR for *;
+    using BytesCBOR for bytes;
+
+    /// @notice the codec received is not valid
+    error InvalidCodec(uint64);
+
+    /// @notice filecoin method not handled
+    error MethodNotHandled(uint64);
+
+    /// @notice utility function meant to handle calls from other builtin actors. Arguments are passed as cbor serialized data (in filecoin native format)
+    /// @param method the filecoin method id that is being called
+    /// @param params raw data (in bytes) passed as arguments to the method call
+    function handleFilecoinMethod(uint64 method, uint64 codec, bytes calldata params) internal pure returns (CommonTypes.UniversalReceiverParams memory) {
+        if (method == CommonTypes.UniversalReceiverHookMethodNum) {
+            if (codec != Misc.CBOR_CODEC) {
+                revert InvalidCodec(codec);
+            }
+
+            return params.deserializeUniversalReceiverParams();
+        } else {
+            revert MethodNotHandled(method);
+        }
+    }
+
+    /// @param target The actor id you want to interact with
+    function universalReceiverHook(CommonTypes.FilActorId target, CommonTypes.UniversalReceiverParams memory params) internal returns (int256, bytes memory) {
+        bytes memory raw_request = params.serializeUniversalReceiverParams();
+
+        (int256 exit_code, bytes memory result) = Actor.callByID(target, CommonTypes.UniversalReceiverHookMethodNum, Misc.CBOR_CODEC, raw_request, 0, false);
+
+        return (exit_code, result);
+    }
+}

--- a/contracts/v0.8/utils/UtilsHandlers.sol
+++ b/contracts/v0.8/utils/UtilsHandlers.sol
@@ -19,11 +19,7 @@
 pragma solidity ^0.8.17;
 
 import "../types/CommonTypes.sol";
-import "../types/AccountTypes.sol";
-import "../types/DataCapTypes.sol";
 
-import "../cbor/AccountCbor.sol";
-import "../cbor/BytesCbor.sol";
 import "../cbor/FilecoinCbor.sol";
 
 import "../utils/Actor.sol";
@@ -31,9 +27,7 @@ import "../utils/Actor.sol";
 /// @title Library containing common handler functions used in the project
 /// @author Zondax AG
 library UtilsHandlers {
-    using AccountCBOR for *;
     using FilecoinCBOR for *;
-    using BytesCBOR for bytes;
 
     /// @notice the codec received is not valid
     error InvalidCodec(uint64);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "filecoin-solidity-api",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Filecoin EVM Solidity APIs",
     "main": "",
     "directories": {
@@ -43,9 +43,7 @@
         "hardhat": "^2.11.2",
         "prettier": "^2.7.1",
         "prettier-plugin-solidity": "^1.0.0",
-        "typechain": "^8.3.1"
-    },
-    "dependencies": {
+        "typechain": "^8.3.1",
         "@glif/filecoin-address": "^2.0.43",
         "@nomiclabs/hardhat-etherscan": "^3.1.7",
         "@typechain/ethers-v5": "^11.1.1",
@@ -56,8 +54,10 @@
         "cids": "^1.1.9",
         "hardhat-contract-sizer": "^2.10.0",
         "hardhat-deploy-ethers": "^0.3.0-beta.13",
-        "solidity-cborutils": "^2.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
+    },
+    "dependencies": {
+        "solidity-cborutils": "^2.0.0"
     }
 }


### PR DESCRIPTION
### Description

There was an issue when trying to flatten a contract using Remix IDE, while the flattening worked in Foundry/Hardhat.

It was caused by one circular import that the compilation could handle but flattening couldn't.

### Affected issues
- fixes: #49