### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ npm install filecoin-solidity-api
 $ forge install filecoin-project/filecoin-solidity
 ```
 
-Add `filecoin-solidity-api=lib/filecoin-project/filecoin-solidity/` in `remappings.txt.`
+Add `filecoin-solidity-api=lib/filecoin-solidity/` in `remappings.txt.`
 
 
 #### Usage


### PR DESCRIPTION
The generated library for foundry doesn't have `filecoin-project/` in path.

<img width="313" alt="image" src="https://github.com/filecoin-project/filecoin-solidity/assets/1265027/403291cc-efbc-4f0c-bf70-b9166978d65e">
